### PR TITLE
Changes to setup.py process to enable upload to pypi servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 tests/__pycache__/
 *.egg-info
+MANIFEST*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .coverage
 dist/
 tests/__pycache__/
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,17 @@
-from distutils.core import setup
+from setuptools import (
+    setup,
+    find_packages
+)
+from datetime import datetime
+
+version = "0.1.0+{}".format(datetime.now().strftime("%Y%m%d.%H%M%S"))
 
 setup(
     name='dsert',
-    version='0.1.0',
-    url='',
+    packages=find_packages(),
+    include_package_data=True,
+    version=version,
+    url='https://github.com/paxos-bankchain/dsert',
     license='',
     author='paxosdev',
     author_email='',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(
-    name='subconscious',
+    name='dsert',
     version='0.1.0',
     url='',
     license='',


### PR DESCRIPTION
Hi!  Saw your presentation at our offices last week and decided to give your module a try.  The setup.py had name 'subconscious' while the package is presumably called 'dsert', which made my `pip install` install subconscious, making the import rather difficult.

I renamed to `dsert` in the setup.py which enables me to `from dsert import assert_valid_dict`.

Thanks for this module, it's a lifesaver if you have to validate dict responses!